### PR TITLE
Taskfile changes for sleep task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,6 +6,7 @@ vars:
   DC_DIR: "deployment/docker-compose"
   INFRA_DC_FILE: "{{.DC_DIR}}/infra.yml"
   APPS_DC_FILE: "{{.DC_DIR}}/apps.yml"
+  SLEEP_CMD: '{{if eq .GOOS "windows"}}timeout{{else}}sleep{{end}}'
 
 tasks:
   default:
@@ -60,4 +61,4 @@ tasks:
     vars:
       DURATION: "{{default 5 .DURATION}}"
     cmds:
-      - sleep {{.DURATION}}
+      - "{{.SLEEP_CMD}} {{.DURATION}}"


### PR DESCRIPTION
In windows system, sleep command is not recognized need to use timeout command instead. Changes done in Taskfile to dynamically change command based on OS.