### PR TITLE
Add Valid annotation for OrderItem annotations to work

### DIFF
--- a/order-service/src/main/java/com/sivalabs/bookstore/orders/domain/models/CreateOrderRequest.java
+++ b/order-service/src/main/java/com/sivalabs/bookstore/orders/domain/models/CreateOrderRequest.java
@@ -5,6 +5,6 @@ import jakarta.validation.constraints.NotEmpty;
 import java.util.Set;
 
 public record CreateOrderRequest(
-        @NotEmpty(message = "Items cannot be empty") Set<OrderItem> items,
+        @Valid @NotEmpty(message = "Items cannot be empty") Set<OrderItem> items,
         @Valid Customer customer,
         @Valid Address deliveryAddress) {}


### PR DESCRIPTION
Without Valid annotation the internal validations won't be triggered.